### PR TITLE
Fix repetition bug

### DIFF
--- a/src/stonefish/evaluation.rs
+++ b/src/stonefish/evaluation.rs
@@ -11,12 +11,12 @@ pub enum Evaluation {
     PlayerCheckmate(usize),
     /// The opponent can give checkmate in the given number of plies.
     OpponentCheckmate(usize),
+    /// A draw, e.g. through threefold-repetition
+    Draw,
 }
 use std::cmp::Ordering;
 
 impl Evaluation {
-    pub const DRAW: Evaluation = Evaluation::Centipawns(0);
-
     /// Determine if the evaluation is a forced checkmate.
     pub fn is_forced_mate(&self) -> bool {
         !matches!(self, &Evaluation::Centipawns(_))
@@ -28,6 +28,7 @@ impl Evaluation {
             Evaluation::Centipawns(mat) => Evaluation::Centipawns(-mat),
             Evaluation::PlayerCheckmate(plies) => Evaluation::OpponentCheckmate(*plies),
             Evaluation::OpponentCheckmate(plies) => Evaluation::PlayerCheckmate(*plies),
+            Evaluation::Draw => Evaluation::Draw,
         }
     }
 
@@ -43,6 +44,7 @@ impl Evaluation {
             Evaluation::Centipawns(mat) => Evaluation::Centipawns(*mat),
             Evaluation::PlayerCheckmate(plies) => Evaluation::PlayerCheckmate(plies + 1),
             Evaluation::OpponentCheckmate(plies) => Evaluation::OpponentCheckmate(plies + 1),
+            Evaluation::Draw => Evaluation::Draw,
         }
     }
 }
@@ -56,6 +58,7 @@ impl Ord for Evaluation {
                 Evaluation::Centipawns(mat_b) => mat_a.cmp(mat_b),
                 Evaluation::PlayerCheckmate(_) => Ordering::Less,
                 Evaluation::OpponentCheckmate(_) => Ordering::Greater,
+                Evaluation::Draw => 0.cmp(mat_a),
             },
             Evaluation::PlayerCheckmate(moves_a) => {
                 match other {
@@ -71,6 +74,14 @@ impl Ord for Evaluation {
                     Evaluation::OpponentCheckmate(moves_b) => moves_a.cmp(moves_b),
                     // Everything is better than getting mated by the opponent
                     _ => Ordering::Less,
+                }
+            }
+            Evaluation::Draw => {
+                match other {
+                    Evaluation::Centipawns(mat_b) => 0.cmp(mat_b),
+                    Evaluation::PlayerCheckmate(_) => Ordering::Less,
+                    Evaluation::OpponentCheckmate(_) => Ordering::Greater,
+                    Evaluation::Draw => Ordering::Equal,
                 }
             }
         }

--- a/src/stonefish/evaluation.rs
+++ b/src/stonefish/evaluation.rs
@@ -17,8 +17,8 @@ pub enum Evaluation {
 use std::cmp::Ordering;
 
 impl Evaluation {
-    /// Determine if the evaluation is a forced checkmate.
-    pub fn is_forced_mate(&self) -> bool {
+    /// Determine if the evaluation marks the end of the game.
+    pub fn is_game_over(&self) -> bool {
         !matches!(self, &Evaluation::Centipawns(_))
     }
 
@@ -109,11 +109,13 @@ mod tests {
     use super::Evaluation;
 
     #[test]
-    fn should_recognize_forced_mate() {
-        assert!(Evaluation::PlayerCheckmate(3).is_forced_mate());
-        assert!(Evaluation::OpponentCheckmate(3).is_forced_mate());
-        assert_eq!(Evaluation::Centipawns(100).is_forced_mate(), false);
-        assert_eq!(Evaluation::Centipawns(-100).is_forced_mate(), false);
+    fn should_recognize_game_over() {
+        assert!(Evaluation::PlayerCheckmate(3).is_game_over());
+        assert!(Evaluation::OpponentCheckmate(3).is_game_over());
+        assert!(Evaluation::Draw.is_game_over());
+        assert_eq!(Evaluation::Centipawns(100).is_game_over(), false);
+        assert_eq!(Evaluation::Centipawns(-100).is_game_over(), false);
+        assert_eq!(Evaluation::Centipawns(0).is_game_over(), false);
     }
 
     #[test]

--- a/src/stonefish/heuristic/mod.rs
+++ b/src/stonefish/heuristic/mod.rs
@@ -48,7 +48,7 @@ pub fn final_heuristic(old_eval: Evaluation, board: &Board) -> Evaluation {
     let delta = if board.checkmate() {
         return Evaluation::OpponentCheckmate(0);
     } else if board.stalemate() {
-        return Evaluation::DRAW;
+        return Evaluation::Draw;
     } else {
         threat_value(board)
     };

--- a/src/stonefish/node/info.rs
+++ b/src/stonefish/node/info.rs
@@ -24,7 +24,8 @@ impl Node {
     pub fn send_info(&self, duration: Duration) {
         // The evaluation of the current position
         let score = match self.evaluation {
-            Evaluation::Centipawns(cp) => format!("cp {}", cp),
+            Evaluation::Centipawns(cp) => format!("cp {cp}"),
+            Evaluation::Draw => format!("cp 0"),
             Evaluation::PlayerCheckmate(plies) => {
                 // Convert plies to moves
                 format!("mate {}", (plies as f32 / 2.0).ceil() as i32)

--- a/src/stonefish/node/iterative_deepening.rs
+++ b/src/stonefish/node/iterative_deepening.rs
@@ -69,7 +69,7 @@ impl Node {
 
                 let mut hash_table = HashTable::new();
                 let mut repetition_table = repetition_table.clone();
-                if repetition_table.insert_check_draw(&self.board) {
+                if repetition_table.insert_check_draw(&child.board) {
                     repetition_table.remove(&self.board);
                     child.evaluation = Evaluation::Draw;
                     tx.send((child, Ok(Evaluation::Draw))).unwrap();
@@ -116,7 +116,7 @@ impl Node {
 
             // If the time is limited and there is a forced mate, just play it out
             let play_forced_mate =
-                self.evaluation.is_forced_mate() && (max_depth.is_some() || max_time.is_some());
+                self.evaluation.is_game_over() && (max_depth.is_some() || max_time.is_some());
 
             if abort || play_forced_mate {
                 break;
@@ -221,7 +221,7 @@ mod tests {
             );
 
             assert!(
-                !node.evaluation.is_forced_mate(),
+                !node.evaluation.is_game_over(),
                 "'{}': {:?}",
                 fen,
                 node.evaluation
@@ -232,6 +232,7 @@ mod tests {
     #[test]
     fn should_always_respond_with_move() {
         let params = [(
+            // position fen 3rk2r/ppp2p1p/3p1n2/6P1/2Pb4/3P3P/PP3RBK/RNB5 w k - 0 17 moves f2d2 d4e5 h2g1 e5d4 g1h2
             "3rk2r/ppp2p1p/3p1n2/6P1/2Pb4/3P3P/PP3RBK/RNB5 w k - 0 17",
             vec!["f2d2", "d4e5", "h2g1", "e5d4", "g1h2"],
         )];

--- a/src/stonefish/node/iterative_deepening.rs
+++ b/src/stonefish/node/iterative_deepening.rs
@@ -71,8 +71,8 @@ impl Node {
                 let mut repetition_table = repetition_table.clone();
                 if repetition_table.insert_check_draw(&self.board) {
                     repetition_table.remove(&self.board);
-                    child.evaluation = Evaluation::DRAW;
-                    tx.send((child, Ok(Evaluation::DRAW))).unwrap();
+                    child.evaluation = Evaluation::Draw;
+                    tx.send((child, Ok(Evaluation::Draw))).unwrap();
                     continue;
                 }
 

--- a/src/stonefish/node/iterative_deepening.rs
+++ b/src/stonefish/node/iterative_deepening.rs
@@ -202,7 +202,10 @@ mod tests {
     #[test]
     fn should_not_wrongly_assume_mate() {
         let paramerters = [
-            ("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", 3),
+            (
+                "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+                3,
+            ),
             ("8/r1N1k1pp/b4p2/3Qp3/P6q/4P3/2PP1PPP/R3K2R w KQ - 1 25", 3),
             // TODO: Fix mate here
             ("4r3/1b2rpk1/p6R/1p4p1/2pN4/P1P2P2/1P3KP1/R7 w - - 2 29", 5),
@@ -223,6 +226,80 @@ mod tests {
                 fen,
                 node.evaluation
             );
+        }
+    }
+
+    #[test]
+    fn should_always_respond_with_move() {
+        let params = [(
+            "3rk2r/ppp2p1p/3p1n2/6P1/2Pb4/3P3P/PP3RBK/RNB5 w k - 0 17",
+            vec!["f2d2", "d4e5", "h2g1", "e5d4", "g1h2"],
+        )];
+
+        for (fen, uci_moves) in params {
+            let mut board = Board::from_fen(fen).unwrap();
+            let mut repetition_table = RepetitionTable::new();
+
+            // Apply the moves and add them to the repetition table
+            for uci_move in uci_moves {
+                assert!(board.apply_uci_move(uci_move));
+                repetition_table.insert(&board);
+            }
+
+            // Construct a node and start searching
+            let mut node = Node::new(board);
+            node.iterative_deepening(
+                Some(3),
+                None,
+                repetition_table,
+                Arc::new(AtomicBool::new(false)),
+            );
+
+            // The bot should give a response
+            assert!(node.best_line.len() > 0);
+        }
+    }
+
+    #[test]
+    fn should_respond_with_repetition() {
+        let params = [
+            (
+                "3rk2r/ppp2p1p/3p1n2/6P1/2Pb4/3P3P/PP1R2BK/RNB5 b k - 5 19",
+                2,
+            ),
+            (
+                "3rk2r/ppp2p1p/3p1n2/6P1/2Pb4/3P3P/PP1R2BK/RNB5 b k - 5 19",
+                3,
+            ),
+            (
+                "3rk2r/ppp2p1p/3p1n2/6P1/2Pb4/3P3P/PP1R2BK/RNB5 b k - 5 19",
+                4,
+            ),
+            (
+                "3rk2r/ppp2p1p/3p1n2/6P1/2Pb4/3P3P/PP1R2BK/RNB5 b k - 5 19",
+                5,
+            ),
+        ];
+
+        for (fen, repetitions) in params {
+            let board = Board::from_fen(fen).unwrap();
+            let mut repetition_table = RepetitionTable::new();
+
+            for _ in 0..repetitions {
+                repetition_table.insert(&board);
+            }
+
+            // Construct a node and start searching
+            let mut node = Node::new(board);
+            node.iterative_deepening(
+                Some(3),
+                None,
+                repetition_table,
+                Arc::new(AtomicBool::new(false)),
+            );
+
+            // The bot should give a response
+            assert!(node.best_line.len() > 0);
         }
     }
 }

--- a/src/stonefish/node/minimax.rs
+++ b/src/stonefish/node/minimax.rs
@@ -24,7 +24,7 @@ impl Node {
         // Check for repetition
         if repetition_table.insert_check_draw(&self.board) {
             repetition_table.remove(&self.board);
-            return Ok(Evaluation::DRAW);
+            return Ok(Evaluation::Draw);
         }
 
         if depth == 0 {


### PR DESCRIPTION
The bot had a bug where it would not respond, shortly before a threefold repetition would occur.
This was because the current position would be inserted one time too much in the repetition table.

Additionally, the bot can now differentiate between equal positions and a draw.