### PR TITLE
Move to stable Rust

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(str_split_whitespace_as_str)]
 use stonefish::Stonefish;
 use uci::UciRunner;
 

--- a/src/stonefish/abort_flags.rs
+++ b/src/stonefish/abort_flags.rs
@@ -6,7 +6,7 @@ use std::sync::{
 use crate::uci::AbortFlag;
 
 /// The search has been aborted.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct SearchAborted;
 
 #[derive(Debug, Clone)]

--- a/src/stonefish/heuristic/positional_value.rs
+++ b/src/stonefish/heuristic/positional_value.rs
@@ -1,6 +1,10 @@
 //! Evaluation of the positional value.
 //!
 //! Values inspired by https://www.chessprogramming.org/Simplified_Evaluation_Function
+
+// The groups represent chess board rows, so they are groups of 8.
+#![allow(clippy::unusual_byte_groupings)]
+
 use pleco::{BitBoard, BitMove, Board, PieceType, Player, SQ};
 
 use super::material_value::get_piece_value;
@@ -323,7 +327,7 @@ pub fn move_positional_value(old_board: &Board, mv: BitMove, new_board: &Board) 
         let old_king_eval = player_king_position(old_board, src_king_bb, player);
         let new_king_eval = player_king_position(new_board, dest_king_bb, player);
 
-        return new_king_eval + new_rook_eval - old_king_eval - old_rook_eval
+        return new_king_eval + new_rook_eval - old_king_eval - old_rook_eval;
     }
 
     let src_sq = mv.get_src();

--- a/src/stonefish/mod.rs
+++ b/src/stonefish/mod.rs
@@ -2,8 +2,8 @@ mod abort_flags;
 mod evaluation;
 mod heuristic;
 mod node;
-mod types;
 mod time_management;
+mod types;
 
 use pleco::Board;
 
@@ -16,7 +16,7 @@ use crate::{
     },
 };
 
-use self::{types::RepetitionTable, time_management::get_max_time};
+use self::{time_management::get_max_time, types::RepetitionTable};
 
 #[derive(Debug, Clone)]
 pub struct Stonefish {
@@ -130,7 +130,7 @@ impl UciEngine for Stonefish {
         // if parts of the moves are invalid
         let mut repetition_table = self.repetition_table.clone();
 
-        if moves.len() == 0 {
+        if moves.is_empty() {
             // No move history was provided, try to reconstruct it
             Self::reconstruct_move_history(&self.board, &new_board, &mut repetition_table);
         } else {

--- a/src/stonefish/node/info.rs
+++ b/src/stonefish/node/info.rs
@@ -25,7 +25,7 @@ impl Node {
         // The evaluation of the current position
         let score = match self.evaluation {
             Evaluation::Centipawns(cp) => format!("cp {cp}"),
-            Evaluation::Draw => format!("cp 0"),
+            Evaluation::Draw => "cp 0".to_string(),
             Evaluation::PlayerCheckmate(plies) => {
                 // Convert plies to moves
                 format!("mate {}", (plies as f32 / 2.0).ceil() as i32)

--- a/src/uci/uci_command.rs
+++ b/src/uci/uci_command.rs
@@ -1,6 +1,6 @@
 use std::str::SplitWhitespace;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum UciCommand {
     Uci,
     Debug(bool),
@@ -15,13 +15,13 @@ pub enum UciCommand {
     Unknown(String),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum UciPosition {
     Fen(String),
     Startpos,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct UciGoConfig {
     /// Restrict search to these moves only.
     pub search_moves: Option<Vec<String>>,
@@ -284,7 +284,7 @@ impl UciCommand {
 
 impl From<&str> for UciCommand {
     fn from(line: &str) -> Self {
-        let mut tokens = line.trim().split_whitespace();
+        let mut tokens = line.split_whitespace();
 
         if let Some(cmd_token) = tokens.next() {
             let rest = &rest_str(&tokens);

--- a/src/uci/uci_command.rs
+++ b/src/uci/uci_command.rs
@@ -1,3 +1,5 @@
+use std::str::SplitWhitespace;
+
 #[derive(Debug, PartialEq)]
 pub enum UciCommand {
     Uci,
@@ -284,27 +286,17 @@ impl From<&str> for UciCommand {
     fn from(line: &str) -> Self {
         let mut tokens = line.trim().split_whitespace();
 
-        return if let Some(cmd_token) = tokens.next() {
+        if let Some(cmd_token) = tokens.next() {
+            let rest = &rest_str(&tokens);
+
             match cmd_token {
                 "uci" => UciCommand::Uci,
-                "debug" => {
-                    let debug_str = tokens.as_str();
-                    UciCommand::try_parse_debug(debug_str)
-                }
+                "debug" => UciCommand::try_parse_debug(rest),
                 "isready" => UciCommand::IsReady,
-                "setoption" => {
-                    let set_option_str = tokens.as_str();
-                    UciCommand::try_parse_set_option(set_option_str)
-                }
+                "setoption" => UciCommand::try_parse_set_option(rest),
                 "ucinewgame" => UciCommand::UciNewGame,
-                "position" => {
-                    let pos_str = tokens.as_str();
-                    UciCommand::try_parse_position(line, pos_str)
-                }
-                "go" => {
-                    let go_str = tokens.as_str();
-                    UciCommand::try_parse_go(go_str)
-                }
+                "position" => UciCommand::try_parse_position(line, rest),
+                "go" => UciCommand::try_parse_go(rest),
                 "stop" => UciCommand::Stop,
                 "ponderhit" => UciCommand::Ponderhit,
                 "quit" => UciCommand::Quit,
@@ -314,8 +306,17 @@ impl From<&str> for UciCommand {
         } else {
             // Unknown (empty) command
             UciCommand::Unknown(line.to_owned())
-        };
+        }
     }
+}
+
+/// Get the rest of the tokens as `&str`.
+///
+/// Temporary workaround until `str_split_whitespace_as_str` has been stabilized.
+/// See <https://github.com/rust-lang/rust/issues/77998>.
+fn rest_str(tokens: &SplitWhitespace) -> String {
+    let token_vec: Vec<_> = tokens.clone().into_iter().collect();
+    token_vec.join(" ")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #8.

This PR removes the usage of the `str_split_whitespace_as_str` unstable feature (using a workaround instead) to allow the engine to be compiled on stable Rust.

Additionally, newly introduced Clippy warnings have been fixed.