### PR TITLE
Update rust version

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(str_split_whitespace_as_str)]
+#![feature(str_split_whitespace_remainder)]
 use stonefish::Stonefish;
 use uci::UciRunner;
 

--- a/src/stonefish/mod.rs
+++ b/src/stonefish/mod.rs
@@ -2,8 +2,8 @@ mod abort_flags;
 mod evaluation;
 mod heuristic;
 mod node;
-mod types;
 mod time_management;
+mod types;
 
 use pleco::Board;
 
@@ -16,7 +16,7 @@ use crate::{
     },
 };
 
-use self::{types::RepetitionTable, time_management::get_max_time};
+use self::{time_management::get_max_time, types::RepetitionTable};
 
 #[derive(Debug, Clone)]
 pub struct Stonefish {
@@ -130,7 +130,7 @@ impl UciEngine for Stonefish {
         // if parts of the moves are invalid
         let mut repetition_table = self.repetition_table.clone();
 
-        if moves.len() == 0 {
+        if moves.is_empty() {
             // No move history was provided, try to reconstruct it
             Self::reconstruct_move_history(&self.board, &new_board, &mut repetition_table);
         } else {

--- a/src/stonefish/node/info.rs
+++ b/src/stonefish/node/info.rs
@@ -25,7 +25,7 @@ impl Node {
         // The evaluation of the current position
         let score = match self.evaluation {
             Evaluation::Centipawns(cp) => format!("cp {cp}"),
-            Evaluation::Draw => format!("cp 0"),
+            Evaluation::Draw => "cp 0".to_string(),
             Evaluation::PlayerCheckmate(plies) => {
                 // Convert plies to moves
                 format!("mate {}", (plies as f32 / 2.0).ceil() as i32)

--- a/src/uci/uci_command.rs
+++ b/src/uci/uci_command.rs
@@ -288,21 +288,21 @@ impl From<&str> for UciCommand {
             match cmd_token {
                 "uci" => UciCommand::Uci,
                 "debug" => {
-                    let debug_str = tokens.as_str();
+                    let debug_str = tokens.remainder().unwrap_or("");
                     UciCommand::try_parse_debug(debug_str)
                 }
                 "isready" => UciCommand::IsReady,
                 "setoption" => {
-                    let set_option_str = tokens.as_str();
+                    let set_option_str = tokens.remainder().unwrap_or("");
                     UciCommand::try_parse_set_option(set_option_str)
                 }
                 "ucinewgame" => UciCommand::UciNewGame,
                 "position" => {
-                    let pos_str = tokens.as_str();
+                    let pos_str = tokens.remainder().unwrap_or("");
                     UciCommand::try_parse_position(line, pos_str)
                 }
                 "go" => {
-                    let go_str = tokens.as_str();
+                    let go_str = tokens.remainder().unwrap_or("");
                     UciCommand::try_parse_go(go_str)
                 }
                 "stop" => UciCommand::Stop,

--- a/src/uci/uci_command.rs
+++ b/src/uci/uci_command.rs
@@ -282,7 +282,7 @@ impl UciCommand {
 
 impl From<&str> for UciCommand {
     fn from(line: &str) -> Self {
-        let mut tokens = line.trim().split_whitespace();
+        let mut tokens = line.split_whitespace();
 
         return if let Some(cmd_token) = tokens.next() {
             match cmd_token {


### PR DESCRIPTION
Update to the latest nightly Rust version.

The `str_split_whitespace_as_str` feature has been renamed to `str_split_whitespace_remainder` and the `as_str` functions to `remainder`.

I also fixed newly enabled Clippy lints.