### PR TITLE
Fix draw recognition

### DIFF
--- a/src/stonefish/evaluation.rs
+++ b/src/stonefish/evaluation.rs
@@ -58,7 +58,7 @@ impl Ord for Evaluation {
                 Evaluation::Centipawns(mat_b) => mat_a.cmp(mat_b),
                 Evaluation::PlayerCheckmate(_) => Ordering::Less,
                 Evaluation::OpponentCheckmate(_) => Ordering::Greater,
-                Evaluation::Draw => 0.cmp(mat_a),
+                Evaluation::Draw => mat_a.cmp(&0),
             },
             Evaluation::PlayerCheckmate(moves_a) => {
                 match other {
@@ -76,14 +76,12 @@ impl Ord for Evaluation {
                     _ => Ordering::Less,
                 }
             }
-            Evaluation::Draw => {
-                match other {
-                    Evaluation::Centipawns(mat_b) => 0.cmp(mat_b),
-                    Evaluation::PlayerCheckmate(_) => Ordering::Less,
-                    Evaluation::OpponentCheckmate(_) => Ordering::Greater,
-                    Evaluation::Draw => Ordering::Equal,
-                }
-            }
+            Evaluation::Draw => match other {
+                Evaluation::Centipawns(mat_b) => 0.cmp(mat_b),
+                Evaluation::PlayerCheckmate(_) => Ordering::Less,
+                Evaluation::OpponentCheckmate(_) => Ordering::Greater,
+                Evaluation::Draw => Ordering::Equal,
+            },
         }
     }
 }
@@ -210,5 +208,41 @@ mod tests {
 
         assert_eq!(eval.cmp(&checkmate), Ordering::Greater);
         assert_eq!(checkmate.cmp(&eval), Ordering::Less);
+    }
+
+    #[test]
+    fn should_compare_draw_with_player_checkmate() {
+        let draw = Evaluation::Draw;
+        let player_checkmate = Evaluation::PlayerCheckmate(3);
+
+        assert_eq!(draw.cmp(&player_checkmate), Ordering::Less);
+        assert_eq!(player_checkmate.cmp(&draw), Ordering::Greater);
+    }
+
+    #[test]
+    fn should_compare_draw_with_opponent_checkmate() {
+        let draw = Evaluation::Draw;
+        let opponent_checkmate = Evaluation::OpponentCheckmate(3);
+
+        assert_eq!(draw.cmp(&opponent_checkmate), Ordering::Greater);
+        assert_eq!(opponent_checkmate.cmp(&draw), Ordering::Less);
+    }
+
+    #[test]
+    fn should_compare_draw_with_bad_eval() {
+        let draw = Evaluation::Draw;
+        let bad_eval = Evaluation::Centipawns(-100);
+
+        assert_eq!(draw.cmp(&bad_eval), Ordering::Greater);
+        assert_eq!(bad_eval.cmp(&draw), Ordering::Less);
+    }
+
+    #[test]
+    fn should_compare_draw_with_good_eval() {
+        let draw = Evaluation::Draw;
+        let good_eval = Evaluation::Centipawns(100);
+
+        assert_eq!(draw.cmp(&good_eval), Ordering::Less);
+        assert_eq!(good_eval.cmp(&draw), Ordering::Greater);
     }
 }

--- a/src/stonefish/node/iterative_deepening.rs
+++ b/src/stonefish/node/iterative_deepening.rs
@@ -87,6 +87,7 @@ impl Node {
                             &mut repetition_table,
                             abort_flags,
                         );
+                        repetition_table.remove(&child.board);
                         tx.send((child, result)).unwrap();
                     })
                     .unwrap();

--- a/src/stonefish/types.rs
+++ b/src/stonefish/types.rs
@@ -24,7 +24,7 @@ pub type HashTable = HashMap<u64, HashTableEntry>;
 pub type Line = Vec<BitMove>;
 pub type Children = Vec<Node>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RepetitionTable(HashMap<u64, usize>);
 
 impl RepetitionTable {
@@ -48,10 +48,10 @@ impl RepetitionTable {
     }
 
     /// Add the board to the repitition table and check if it's a draw.
-    /// 
+    ///
     /// It is a draw if the position occurred 3 times (a player has to claim the draw)
     /// or if the position occurred 5 times (automatic draw).
-    /// 
+    ///
     /// See <https://lichess.org/faq#threefold>
     pub fn insert_check_draw(&mut self, board: &Board) -> bool {
         let occurances = self.insert(board);


### PR DESCRIPTION
Fixes #11.

This fixes two bugs:

- Sometimes the repetition table was not updated correctly. The updating is now also simpler than before.
- Draws were wrongly compared to material evaluations. This could lead to the bot forcing a draw in a winning position.